### PR TITLE
Allow disabling debug background elements

### DIFF
--- a/src/mesh_system.rs
+++ b/src/mesh_system.rs
@@ -83,7 +83,7 @@ pub(crate) fn text_mesh(
                     ..Default::default()
                 });
 
-                if 1 < 10 {
+                if option_env!("DEBUG_TEXT_MESH").is_some() {
                     bundle.with_children(|cmd| {
                         cmd.spawn_bundle(PbrBundle {
                             mesh: meshes.add(Mesh::from(shape::Box::new(


### PR DESCRIPTION
I'm not sure these background boxes are intended to stay anyway, but this makes it easier to use the develop branch in other apps, until Bevy 0.6 support is published.