### PR TITLE
Add a note about incompatibility with bevy_text (see #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The text mesh is generated at runtime from runtime-tessellated (and cached) True
 Consider this as a preview of the plugin for gathering feedback about the API:
 
 - **The API will change in future - still iterating**
-- **Incompatible with `bevy_text` (2D)** - crate exposes its own asset loader for `.ttf` files, and replaces any other loaders. See #9
+- **Incompatible with `bevy_text` (2D)** - crate exposes its own asset loader for `.ttf` files, and replaces any other loaders. See [issue #9](https://github.com/blaind/bevy_text_mesh/issues/9)
 - Multiple `TextMesh` configuration fields are not implemented yet, see example below
 - Text color update is not implemented yet
 - Spacing of characters are incorrect


### PR DESCRIPTION
Also removed the note about the untrusted input, since ttf2mesh has now been fuzzed (see https://github.com/blaind/ttf2mesh-rs/tree/main/fuzz) and findings have been fixed upstream.