### PR TITLE
Libclang required for compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ commands.spawn(TextMeshBundle {
 });
 ```
 
+## Libclang
+
+Download <a href="https://releases.llvm.org/download.html">libclang</a> directly for Windows, or use a similar package manager command such as:
+
+``apt get libclang-dev``
+
 ## License
 
 Licensed under <a href="LICENSE">MIT license</a>


### PR DESCRIPTION
Many people don't have it by default.