### PR TITLE
Updated to Bevy 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 glyph_brush_layout = "0.2.3"
 
 [dependencies.bevy]
-version = "0.12.0"
+version = "0.13.0"
 default-features = false
 features = ["bevy_render", "bevy_text", "bevy_pbr", "bevy_asset", "bevy_sprite"]
 
@@ -24,7 +24,7 @@ features = ["bevy_render", "bevy_text", "bevy_pbr", "bevy_asset", "bevy_sprite"]
 rand = "0.8.4"
 
 [dev-dependencies.bevy]
-version = "0.12.0"
+version = "0.13.0"
 default-features = false
 features = [
   "bevy_winit",

--- a/examples/2d_text.rs
+++ b/examples/2d_text.rs
@@ -19,13 +19,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         font_size: 60.0,
         color: Color::WHITE,
     };
-    let text_alignment = TextAlignment::Center;
+    let text_alignment = JustifyText::Center;
 
     commands.spawn(Camera2dBundle::default());
     commands
         .spawn(Text2dBundle {
             text: Text::from_section("standard 2d text works too", text_style.clone())
-                .with_alignment(text_alignment),
+                .with_justify(text_alignment),
             ..default()
         })
         .insert(AnimateRotation);

--- a/examples/3d_scene.rs
+++ b/examples/3d_scene.rs
@@ -109,13 +109,15 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(5.0, 5.0))),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..Default::default()
     });
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(Mesh::from(Cuboid {
+            half_size: Vec3::new(1.0, 0.5, 1.0),
+        })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..Default::default()
     });

--- a/src/font_loader.rs
+++ b/src/font_loader.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 use anyhow::Result;
 use bevy::asset::io::Reader;
 use bevy::asset::{Asset, AssetLoader, BoxedFuture, LoadContext};
-use bevy::reflect::{TypePath, TypeUuid};
+use bevy::reflect::TypePath;
 
 #[derive(Debug)]
 pub struct FontLoaderError;
@@ -59,8 +59,8 @@ impl AssetLoader for FontLoader {
     }
 }
 
-#[derive(TypeUuid, TypePath, Asset)]
-#[uuid = "5415ac03-d009-471e-89ab-dc0d4e31a8c4"]
+#[derive(TypePath, Asset)]
+// #[uuid = "5415ac03-d009-471e-89ab-dc0d4e31a8c4"]
 pub struct TextMeshFont {
     pub(crate) ttf_font: ttf2mesh::TTFFile,
 }


### PR DESCRIPTION
Hey, using [this guide from bevy ](https://bevyengine.org/learn/migration-guides/0-12-to-0-13/)I updated this library to use bevy 0.13.0.

I ran the examples and they all seem to work.

Some observations that may hint to my changes being faulty:

When running I get the following message:
`Duplicate AssetLoader registered for Asset type `bevy_text::font::Font` with extensions `["ttf"]`. Loader must be specified in a .meta file in order to load assets of this type with these extensions.`


For some reason now, even if mesh is `Some`, `meshes.get_mut` may return `None`, maybe this is connected to the above message.
```rust
if let Some(mesh) = mesh {
    if let Some(asset_mesh) = meshes.get_mut(mesh) {
        new_mesh = false;
        let ttf2_mesh =
            generate_text_mesh(&text_mesh, &mut font.ttf_font, Some(&mut cache));
        apply_mesh(ttf2_mesh, asset_mesh);
    }
}
```


I hope my changes are of some use. As said, the examples work at least, so for developing and testing it should be usable.