### PR TITLE
Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_text_mesh"
-version = "0.9.0"
+version = "0.11.0"
 edition = "2021"
 description = "A bevy 3D text mesh generator for displaying text"
 repository = "https://github.com/blaind/bevy_text_mesh"
@@ -10,13 +10,13 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-ttf2mesh = "0.2.0"
+ttf2mesh = "0.2.1"
 bitflags = "2.1"
 anyhow = "1.0"
 glyph_brush_layout = "0.2.3"
 
 [dependencies.bevy]
-version = "0.13.0"
+version = "0.14.0"
 default-features = false
 features = ["bevy_render", "bevy_text", "bevy_pbr", "bevy_asset", "bevy_sprite"]
 
@@ -24,7 +24,7 @@ features = ["bevy_render", "bevy_text", "bevy_pbr", "bevy_asset", "bevy_sprite"]
 rand = "0.8.4"
 
 [dev-dependencies.bevy]
-version = "0.13.0"
+version = "0.14.0"
 default-features = false
 features = [
   "bevy_winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 glyph_brush_layout = "0.2.3"
 
 [dependencies.bevy]
-version = "0.12.0"
+version = "0.13.0"
 default-features = false
 features = ["bevy_render", "bevy_text", "bevy_pbr", "bevy_asset", "bevy_sprite"]
 
@@ -24,7 +24,7 @@ features = ["bevy_render", "bevy_text", "bevy_pbr", "bevy_asset", "bevy_sprite"]
 rand = "0.8.4"
 
 [dev-dependencies.bevy]
-version = "0.12.0"
+version = "0.13.0"
 default-features = false
 features = [
   "bevy_winit",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Consider this as a preview of the plugin for gathering feedback about the API:
 
 | bevy | bevy_text_mesh |
 | ---- | -------------- |
+| 0.14 | 0.11.0         |
+| 0.13 | 0.10.0         |
 | 0.12 | 0.9.0          |
 | 0.11 | 0.7.0          |
 | 0.10 | 0.6.0          |
@@ -62,7 +64,7 @@ Add to Cargo.toml:
 
 ```
 [dependencies]
-bevy_text_mesh = "0.9.0"
+bevy_text_mesh = "0.11.0"
 ```
 
 Include the library:
@@ -92,14 +94,14 @@ Next, you are ready to spawn a text in your scene at a system:
 First, load a font asset:
 
 ```rust
-let font: Handle<TextMeshFont> = asset_server.load("fonts/FiraSans-Medium.ttf#mesh");
+let font: Handle<TextMeshFont> = asset_server.load("fonts/FiraSans-Medium.ttf");
 ```
 
 Then, spawn a textmesh bundle:
 
 ```rust
 commands.spawn(TextMeshBundle {
-    text_mesh: TextMesh::new_with_color("Hello Bevy", font, Color::rgb(1., 1., 0.)),
+    text_mesh: TextMesh::new_with_color("Hello Bevy", font, Color::srgb(1., 1., 0.)),
     transform: Transform::from_xyz(-1., 1.75, 0.),
     ..Default::default()
 });
@@ -114,7 +116,7 @@ commands.spawn(TextMeshBundle {
         style: TextMeshStyle {
             font,
             font_size: SizeUnit::NonStandard(36.),
-            color: Color::rgb(1.0, 1.0, 0.0),
+            color: Color::srgb(1.0, 1.0, 0.0),
             font_style: FontStyle::UPPERCASE, // only UPPERCASE & LOWERCASE implemented currently
             mesh_quality: Quality::Low,
             ..Default::default()

--- a/examples/2d_text.rs
+++ b/examples/2d_text.rs
@@ -19,13 +19,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         font_size: 60.0,
         color: Color::WHITE,
     };
-    let text_alignment = TextAlignment::Center;
+    let text_alignment = JustifyText::Center;
 
     commands.spawn(Camera2dBundle::default());
     commands
         .spawn(Text2dBundle {
             text: Text::from_section("standard 2d text works too", text_style.clone())
-                .with_alignment(text_alignment),
+                .with_justify(text_alignment),
             ..default()
         })
         .insert(AnimateRotation);

--- a/examples/3d_scene.rs
+++ b/examples/3d_scene.rs
@@ -13,7 +13,7 @@ fn main() {
 }
 
 fn setup_text_mesh(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font: Handle<TextMeshFont> = asset_server.load("fonts/FiraMono-Medium.ttf#mesh");
+    let font: Handle<TextMeshFont> = asset_server.load("fonts/FiraMono-Medium.ttf");
 
     commands.spawn(TextMeshBundle {
         text_mesh: TextMesh {
@@ -21,7 +21,7 @@ fn setup_text_mesh(mut commands: Commands, asset_server: Res<AssetServer>) {
             style: TextMeshStyle {
                 font: font.clone(),
                 font_size: SizeUnit::NonStandard(9.),
-                color: Color::rgb(0.0, 0.0, 0.0),
+                color: Color::srgb(0.0, 0.0, 0.0),
                 ..Default::default()
             },
             size: TextMeshSize {
@@ -43,7 +43,7 @@ fn setup_text_mesh(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: TextMeshStyle {
                     font: font.clone(),
                     font_size: SizeUnit::NonStandard(36.),
-                    color: Color::rgb(0.0, 1.0, 0.0),
+                    color: Color::srgb(0.0, 1.0, 0.0),
                     mesh_quality: Quality::Custom(128),
                     ..Default::default()
                 },
@@ -77,7 +77,7 @@ fn update_text_mesh(
 ) {
     if timer.timer.tick(time.delta()).just_finished() {
         for mut text_mesh in text_meshes.iter_mut() {
-            let updated_text = String::from(format!("Time = {:.3}", time.elapsed_seconds_f64()));
+            let updated_text = format!("Time = {:.3}", time.elapsed_seconds_f64());
 
             if text_mesh.text != updated_text {
                 text_mesh.text = updated_text;
@@ -110,14 +110,14 @@ fn setup(
 ) {
     commands.spawn(PbrBundle {
         mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(5.0, 5.0))),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
+        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
         ..Default::default()
     });
     commands.spawn(PbrBundle {
         mesh: meshes.add(Mesh::from(Cuboid {
             half_size: Vec3::new(1.0, 0.5, 1.0),
         })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
+        material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..Default::default()
     });

--- a/examples/3d_scene.rs
+++ b/examples/3d_scene.rs
@@ -109,13 +109,15 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(5.0, 5.0))),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..Default::default()
     });
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(Mesh::from(Cuboid {
+            half_size: Vec3::new(1.0, 0.5, 1.0),
+        })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..Default::default()
     });

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -32,7 +32,7 @@ fn main() {
         .add_plugins((
             DefaultPlugins,
             TextMeshPlugin,
-            FrameTimeDiagnosticsPlugin::default(),
+            FrameTimeDiagnosticsPlugin,
             LogDiagnosticsPlugin::default(),
         ))
         .register_diagnostic(Diagnostic::new(TEXT_MESH_UPDATES).with_max_history_length(20)) // , "text_mesh_updates", 20))
@@ -74,7 +74,7 @@ fn setup_text_mesh(
     asset_server: Res<AssetServer>,
 ) {
     let state = SceneState {
-        font: asset_server.load("fonts/FiraMono-Medium.ttf#mesh"),
+        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
         text_count: 0,
         text_update_count: 0,
         material: materials.add(StandardMaterial {
@@ -90,7 +90,7 @@ fn setup_text_mesh(
                 text: String::from("FPS"),
                 style: TextMeshStyle {
                     font: state.font.clone(),
-                    color: Color::rgb(0., 1., 0.),
+                    color: Color::srgb(0., 1., 0.),
                     font_size: SizeUnit::NonStandard(48.),
                     ..Default::default()
                 },
@@ -108,7 +108,7 @@ fn setup_text_mesh(
                 style: TextMeshStyle {
                     font: state.font.clone(),
                     font_size: SizeUnit::NonStandard(18.),
-                    color: Color::rgb(1., 1., 1.),
+                    color: Color::srgb(1., 1., 1.),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -193,7 +193,7 @@ fn update_text_mesh(
     let mut update_count = 0;
     if timer.text_update_timer.tick(time.delta()).just_finished() {
         for mut text_mesh in text_meshes.iter_mut() {
-            let updated_text = String::from(format!("Time = {:.3}", time.elapsed_seconds_f64()));
+            let updated_text = format!("Time = {:.3}", time.elapsed_seconds_f64());
 
             if text_mesh.text != updated_text {
                 text_mesh.text = updated_text;
@@ -245,7 +245,7 @@ fn update_frame_rate(
         }
 
         let camera_entity = camera_entity.iter().next().unwrap();
-        let camera_transform = transform_query.get_mut(camera_entity).unwrap().clone();
+        let camera_transform = *transform_query.get_mut(camera_entity).unwrap();
         let mut transform = transform_query.get_mut(text_mesh_entity).unwrap();
 
         // eh - why negative?
@@ -261,7 +261,7 @@ fn setup(
 ) {
     commands.spawn(PbrBundle {
         mesh: meshes.add(Mesh::from(Plane3d::default().mesh().size(5.0, 5.0))),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
+        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
         ..Default::default()
     });
     commands.spawn(PointLightBundle {

--- a/src/font_loader.rs
+++ b/src/font_loader.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 use anyhow::Result;
 use bevy::asset::io::Reader;
 use bevy::asset::{Asset, AssetLoader, BoxedFuture, LoadContext};
-use bevy::reflect::{TypePath, TypeUuid};
+use bevy::reflect::TypePath;
 
 #[derive(Debug)]
 pub struct FontLoaderError;
@@ -59,8 +59,8 @@ impl AssetLoader for FontLoader {
     }
 }
 
-#[derive(TypeUuid, TypePath, Asset)]
-#[uuid = "5415ac03-d009-471e-89ab-dc0d4e31a8c4"]
+#[derive(TypePath, Asset)]
+// #[uuid = "5415ac03-d009-471e-89ab-dc0d4e31a8c4"]
 pub struct TextMeshFont {
     pub(crate) ttf_font: ttf2mesh::TTFFile,
 }

--- a/src/mesh_system.rs
+++ b/src/mesh_system.rs
@@ -64,7 +64,7 @@ pub(crate) fn text_mesh(
             if let Some(asset_mesh) = meshes.get_mut(mesh) {
                 new_mesh = false;
                 let ttf2_mesh =
-                    generate_text_mesh(&text_mesh, &mut font.ttf_font, Some(&mut cache));
+                    generate_text_mesh(text_mesh, &mut font.ttf_font, Some(&mut cache));
                 apply_mesh(ttf2_mesh, asset_mesh);
             }
         }
@@ -75,19 +75,19 @@ pub(crate) fn text_mesh(
                 RenderAssetUsages::RENDER_WORLD,
             );
 
-            let ttf2_mesh = generate_text_mesh(&text_mesh, &mut font.ttf_font, Some(&mut cache));
+            let ttf2_mesh = generate_text_mesh(text_mesh, &mut font.ttf_font, Some(&mut cache));
             apply_mesh(ttf2_mesh, &mut mesh);
 
             commands.entity(entity).insert(PbrBundle {
                 mesh: meshes.add(mesh),
-                material: material.map(|m| m.clone()).unwrap_or_else(|| {
+                material: material.cloned().unwrap_or_else(|| {
                     materials.add(StandardMaterial {
                         base_color: text_mesh.style.color,
                         ..Default::default()
                     })
                 }),
-                transform: transform.clone(),
-                global_transform: global_transform.clone(),
+                transform: *transform,
+                global_transform: *global_transform,
                 ..Default::default()
             });
         }


### PR DESCRIPTION
The issue in #36 is solved by not binding an extension and having the FontLoader return our TextMeshFont struct so Bevy can infer which loader to use by the Asset type requested.

When requesting a Font asset, we don't ask for a #mesh label anymore.